### PR TITLE
Support for Wi-Fi/802.11 related radiotap fields: MCS, HE, VHT

### DIFF
--- a/PacketDotNet/Ieee80211/RadioTapFields.cs
+++ b/PacketDotNet/Ieee80211/RadioTapFields.cs
@@ -15,6 +15,306 @@ using PacketDotNet.Utils.Converters;
 
 namespace PacketDotNet.Ieee80211;
 
+
+    /// <summary>
+    /// The presence of this field indicates that the frame was received or transmitted using the VHT PHY (Wi-Fi 5 / ieee802.11ac).
+    /// </summary>
+    public class VeryHighThroughputRadioTapField : RadioTapField
+    {
+        public RadioTapVhtKnown Known { get; set; }
+        public RadioTapVhtFlags Flags { get; set; }
+        public RadioTapVhtBandwidth Bandwidth { get; set; }
+        public RadioTapVhtMcsNss McsNss1 { get; set; }
+        public RadioTapVhtMcsNss McsNss2 { get; set; }
+        public RadioTapVhtMcsNss McsNss3 { get; set; }
+        public RadioTapVhtMcsNss McsNss4 { get; set; }
+
+        /// <summary>
+        /// The coding for a user is only valid if the NSS (in the mcs_nss field) for that user is nonzero.
+        /// </summary>
+        public RadioTapVhtCoding Coding { get; set; }
+        public byte GroupId { get; set; }
+        public ushort PartialAid { get; set; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="br">
+        /// A <see cref="BinaryReader" />
+        /// </param>
+        public VeryHighThroughputRadioTapField(BinaryReader br)
+        {
+            Known = (RadioTapVhtKnown)br.ReadUInt16();
+            Flags = (RadioTapVhtFlags)br.ReadByte();
+            Bandwidth = (RadioTapVhtBandwidth)br.ReadByte();
+            McsNss1 = (RadioTapVhtMcsNss)br.ReadByte();
+            McsNss2 = (RadioTapVhtMcsNss)br.ReadByte();
+            McsNss3 = (RadioTapVhtMcsNss)br.ReadByte();
+            McsNss4 = (RadioTapVhtMcsNss)br.ReadByte();
+            Coding = (RadioTapVhtCoding)br.ReadByte();
+            GroupId = br.ReadByte();
+            PartialAid = br.ReadUInt16();
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VeryHighThroughputRadioTapField" /> class.
+        /// </summary>
+        public VeryHighThroughputRadioTapField()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VeryHighThroughputRadioTapField" /> class.
+        /// </summary>
+        public VeryHighThroughputRadioTapField(
+            RadioTapVhtKnown known, 
+            RadioTapVhtFlags flags, 
+            RadioTapVhtBandwidth bandwidth,
+            RadioTapVhtMcsNss mcsNss1,
+            RadioTapVhtMcsNss mcsNss2,
+            RadioTapVhtMcsNss mcsNss3,
+            RadioTapVhtMcsNss mcsNss4,
+            RadioTapVhtCoding coding,
+            byte groupId,
+            ushort partialAid)
+        {
+            Known = known;
+            Flags = flags;
+            Bandwidth = bandwidth;
+            McsNss1 = mcsNss1;
+            McsNss2 = mcsNss2;
+            McsNss3 = mcsNss3;
+            McsNss4 = mcsNss4;
+            Coding = coding;
+            GroupId = groupId;
+            PartialAid = partialAid;
+        }
+
+        /// <summary>Type of the field</summary>
+        public override RadioTapType FieldType => RadioTapType.VeryHighThroughput;
+
+        /// <summary>
+        /// Gets the length of the field data.
+        /// </summary>
+        /// <value>
+        /// The length.
+        /// </value>
+        public override ushort Length => 12;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <value>The alignment.</value>
+        public override ushort Alignment => 2;
+
+
+        /// <summary>
+        /// Copies the field data to the destination buffer at the specified offset.
+        /// </summary>
+        public override void CopyTo(byte[] dest, int offset)
+        {
+            EndianBitConverter.Little.CopyBytes((ushort)Known, dest, offset);
+            EndianBitConverter.Little.CopyBytes((byte)Flags, dest, offset + 2);
+            EndianBitConverter.Little.CopyBytes((byte)Bandwidth, dest, offset + 3);
+            EndianBitConverter.Little.CopyBytes((byte)McsNss1, dest, offset + 4);
+            EndianBitConverter.Little.CopyBytes((byte)McsNss2, dest, offset + 5);
+            EndianBitConverter.Little.CopyBytes((byte)McsNss3, dest, offset + 6);
+            EndianBitConverter.Little.CopyBytes((byte)McsNss4, dest, offset + 7);
+            EndianBitConverter.Little.CopyBytes((byte)Coding, dest, offset + 8);
+            EndianBitConverter.Little.CopyBytes(GroupId, dest, offset + 9);
+            EndianBitConverter.Little.CopyBytes(PartialAid, dest, offset + 10);
+        }
+
+        /// <summary>
+        /// ToString() override
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string" />
+        /// </returns>
+        public override string ToString()
+        {
+            return $"Known {Known}, Flags {Flags}, Bandwidth {Bandwidth}, McsNss1 {McsNss1}, McsNss2 {McsNss2}, McsNss3 {McsNss3}, McsNss4 {McsNss4}, Coding {Coding}, GroupId {GroupId}, PartialAid {PartialAid}";
+        }
+    }
+
+    /// <summary>
+    /// The presence of this field indicates that the frame was received or transmitted using the HE PHY (Wi-Fi 6 / ieee802.11ax).
+    /// </summary>
+    public class HighEfficiencyRadioTapField : RadioTapField
+    {
+        public RadioTapHighEfficiencyData1 Data1 { get; set; }
+        public RadioTapHighEfficiencyData2 Data2 { get; set; }
+        public ushort Data3 { get; set; }
+        public ushort Data4 { get; set; }
+        public ushort Data5 { get; set; }
+        public ushort Data6 { get; set; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="br">
+        /// A <see cref="BinaryReader" />
+        /// </param>
+        public HighEfficiencyRadioTapField(BinaryReader br)
+        {
+            Data1 = (RadioTapHighEfficiencyData1)br.ReadUInt16();
+            Data2 = (RadioTapHighEfficiencyData2)br.ReadUInt16();
+            Data3 = br.ReadUInt16();
+            Data4 = br.ReadUInt16();
+            Data5 = br.ReadUInt16();
+            Data6 = br.ReadUInt16();
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HighEfficiencyRadioTapField" /> class.
+        /// </summary>
+        public HighEfficiencyRadioTapField()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HighEfficiencyRadioTapField" /> class.
+        /// </summary>
+        public HighEfficiencyRadioTapField(RadioTapHighEfficiencyData1 data1, RadioTapHighEfficiencyData2 data2, ushort data3, ushort data4, ushort data5, ushort data6)
+        {
+            Data1 = data1;
+            Data2 = data2;
+            Data3 = data3;
+            Data4 = data4;
+            Data5 = data5;
+            Data6 = data6;
+        }
+
+        /// <summary>Type of the field</summary>
+        public override RadioTapType FieldType => RadioTapType.HighEfficiency;
+
+        /// <summary>
+        /// Gets the length of the field data.
+        /// </summary>
+        /// <value>
+        /// The length.
+        /// </value>
+        public override ushort Length => 12;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <value>The alignment.</value>
+        public override ushort Alignment => 2;
+
+
+        /// <summary>
+        /// Copies the field data to the destination buffer at the specified offset.
+        /// </summary>
+        public override void CopyTo(byte[] dest, int offset)
+        {
+            EndianBitConverter.Little.CopyBytes((ushort)Data1, dest, offset);
+            EndianBitConverter.Little.CopyBytes((ushort)Data2, dest, offset + 2);
+            EndianBitConverter.Little.CopyBytes(Data3, dest, offset + 4);
+            EndianBitConverter.Little.CopyBytes(Data4, dest, offset + 6);
+            EndianBitConverter.Little.CopyBytes(Data5, dest, offset + 8);
+            EndianBitConverter.Little.CopyBytes(Data6, dest, offset + 10);
+        }
+
+        /// <summary>
+        /// ToString() override
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string" />
+        /// </returns>
+        public override string ToString()
+        {
+            return $"Data1 {Data1}, Data2 {Data2}, Data3 {Data3}, Data4 {Data4}, Data5 {Data5}, Data6 {Data6}";
+        }
+    }
+
+    public class McsRadioTapField : RadioTapField
+    {
+        /// <summary>
+        /// Indicates which information is known
+        /// </summary>
+        public RadioTapMcsKnown Known { get; set; }
+
+        /// <summary>
+        /// Indicates which information is known
+        /// </summary>
+        public RadioTapMcsFlags Flags { get; set; }
+
+        public byte Mcs { get; set; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="br">
+        /// A <see cref="BinaryReader" />
+        /// </param>
+        public McsRadioTapField(BinaryReader br)
+        {
+            Known = (RadioTapMcsKnown)br.ReadByte();
+            Flags = (RadioTapMcsFlags)br.ReadByte();
+            Mcs = br.ReadByte();
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="McsRadioTapField" /> class.
+        /// </summary>
+        public McsRadioTapField()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="McsRadioTapField" /> class.
+        /// <param name="known">Known information</param>
+        /// <param name="flags">MCS Flags</param>
+        /// <param name="mcs">Known information</param>
+        /// </summary>
+        public McsRadioTapField(RadioTapMcsKnown known, RadioTapMcsFlags flags, byte mcs)
+        {
+            Known = known;
+            Flags = flags;
+            Mcs = mcs;
+        }
+
+        /// <summary>Type of the field</summary>
+        public override RadioTapType FieldType => RadioTapType.Mcs;
+
+        /// <summary>
+        /// Gets the length of the field data.
+        /// </summary>
+        /// <value>
+        /// The length.
+        /// </value>
+        public override ushort Length => 3;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <value>The alignment.</value>
+        public override ushort Alignment => 1;
+
+
+        /// <summary>
+        /// Copies the field data to the destination buffer at the specified offset.
+        /// </summary>
+        public override void CopyTo(byte[] dest, int offset)
+        {
+            EndianBitConverter.Little.CopyBytes((byte)Known, dest, offset);
+            EndianBitConverter.Little.CopyBytes((byte)Flags, dest, offset + 1);
+            EndianBitConverter.Little.CopyBytes((byte)Mcs, dest, offset + 2);
+        }
+
+        /// <summary>
+        /// ToString() override
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string" />
+        /// </returns>
+        public override string ToString()
+        {
+            return $"Known {Known}, Flags {Flags}, Mcs {Mcs}";
+        }
+    }
+
     /// <summary>
     /// Channel field
     /// </summary>
@@ -1527,6 +1827,14 @@ namespace PacketDotNet.Ieee80211;
                 case RadioTapType.RxFlags:
                 {
                     return new RxFlagsRadioTapField(br);
+                }
+                case RadioTapType.Mcs:
+                {
+                    return new McsRadioTapField(br);
+                }
+                case RadioTapType.HighEfficiency:
+                {
+                    return new HighEfficiencyRadioTapField(br);
                 }
                 default:
                 {

--- a/PacketDotNet/Ieee80211/RadioTapFields.cs
+++ b/PacketDotNet/Ieee80211/RadioTapFields.cs
@@ -1836,6 +1836,10 @@ namespace PacketDotNet.Ieee80211;
                 {
                     return new HighEfficiencyRadioTapField(br);
                 }
+                case RadioTapType.VeryHighThroughput:
+                {
+                    return new VeryHighThroughputRadioTapField(br);
+                }
                 default:
                 {
                     //the RadioTap fields are extendable so there may be some we dont know about

--- a/PacketDotNet/Ieee80211/RadioTapHighEfficiencyData1.cs
+++ b/PacketDotNet/Ieee80211/RadioTapHighEfficiencyData1.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PacketDotNet.Ieee80211;
+
+[Flags]
+public enum RadioTapHighEfficiencyData1 : ushort
+{
+    HePpduFormat = 0x0003,
+    BssColorKnown = 0x0004,
+    BeamChangeKnown = 0x0008,
+    UlDlDown = 0x0010,
+    DataMcsKnown = 0x0020,
+    DataDcmKnown = 0x0040,
+    CodingKnown = 0x0080,
+    LdpcExtraSymbolSegmentKnown = 0x0100,
+    StbcKnown = 0x0200,
+    SpatialReuseKnownKnown = 0x0400,
+    SpatialReuse2KnownKnown = 0x0800,
+    SpatialReuse3KnownKnown = 0x1000,
+    SpatialReuse4KnownKnown = 0x2000,
+    DataBwRuAllocationKnown = 0x4000,
+    DopplerKnown = 0x8000,
+}

--- a/PacketDotNet/Ieee80211/RadioTapHighEfficiencyData1.cs
+++ b/PacketDotNet/Ieee80211/RadioTapHighEfficiencyData1.cs
@@ -1,8 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*
+This file is part of PacketDotNet.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+/*
+ * Copyright 2010 Chris Morgan <chmorgan@gmail.com>
+ */
+
+using System;
 
 namespace PacketDotNet.Ieee80211;
 

--- a/PacketDotNet/Ieee80211/RadioTapHighEfficiencyData2.cs
+++ b/PacketDotNet/Ieee80211/RadioTapHighEfficiencyData2.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+
+namespace PacketDotNet.Ieee80211;
+
+[Flags]
+public enum RadioTapHighEfficiencyData2 : ushort
+{
+    PriSec80MHzKnown = 0x0001,
+    GiKnown = 0x0002,
+    NumberOfLtfSymbolsKnown = 0x0004,
+    PreFecPaddingFactorKnown = 0x0008,
+    TxbfKnown = 0x0010,
+    PeDisambiguityKnown = 0x0020,
+    TxopKnown = 0x0040,
+    MidamblePeriodicityKnown = 0x0080,
+    RuAllocationOffset = 0x3f00,
+    RuAllocationOffsetKnown = 0x4000,
+
+    /// <summary>
+    /// 0 = primary, 1 = secondary
+    /// </summary>
+    PriSec80MHz = 0x8000,
+}

--- a/PacketDotNet/Ieee80211/RadioTapHighEfficiencyData2.cs
+++ b/PacketDotNet/Ieee80211/RadioTapHighEfficiencyData2.cs
@@ -1,5 +1,15 @@
-﻿using System;
+﻿/*
+This file is part of PacketDotNet.
 
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+/*
+ * Copyright 2010 Chris Morgan <chmorgan@gmail.com>
+ */
+
+using System;
 
 namespace PacketDotNet.Ieee80211;
 

--- a/PacketDotNet/Ieee80211/RadioTapMcsFlags.cs
+++ b/PacketDotNet/Ieee80211/RadioTapMcsFlags.cs
@@ -1,0 +1,39 @@
+﻿/*
+This file is part of PacketDotNet.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+/*
+ * Copyright 2010 Chris Morgan <chmorgan@gmail.com>
+ */
+
+using System;
+
+namespace PacketDotNet.Ieee80211;
+
+    /// <summary>
+    /// Channel flags
+    /// </summary>
+    [Flags]
+    public enum RadioTapMcsFlags : byte
+    {
+        /// <summary>Channel Width: 20MHz=0, 40MHz=1, 20L=2, 20U=3</summary>
+        Bandwidth = 0x03,
+
+        /// <summary>Guard Interval (GI): Long GI=0, Short GI=1</summary>
+        GuardInterval = 0x04,
+
+        /// <summary>HT Format: 0=Mixed, 1=Greenfield</summary>
+        HtFormat = 0x08,
+
+        /// <summary>FEC Type: BCC=0, LDPC=1</summary>
+        FecType = 0x10,
+
+        /// <summary>Number of STBC Streams</summary>
+        NumberOfStbcStreams = 0x60,
+
+        /// <summary>Number of extension spacial streams</summary>
+        Ness = 0x80
+    }

--- a/PacketDotNet/Ieee80211/RadioTapMcsKnown.cs
+++ b/PacketDotNet/Ieee80211/RadioTapMcsKnown.cs
@@ -1,0 +1,45 @@
+﻿/*
+This file is part of PacketDotNet.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+/*
+ * Copyright 2010 Chris Morgan <chmorgan@gmail.com>
+ */
+
+using System;
+
+namespace PacketDotNet.Ieee80211;
+
+    /// <summary>
+    /// Known fields in the MCS radiko tap header
+    /// </summary>
+    [Flags]
+    public enum RadioTapMcsKnown : byte
+    {
+        /// <summary>Bandwidth</summary>
+        Bandwidth = 0x01,
+
+        /// <summary>MCS index</summary>
+        McsIndexKnown = 0x02,
+
+        /// <summary>Guard interval</summary>
+        GuardInterval = 0x04,
+
+        /// <summary>HT Format</summary>
+        HtFormat = 0x08,
+
+        /// <summary>FEC type</summary>
+        FecType = 0x10,
+
+        /// <summary>STBC known</summary>
+        SbtcKnown = 0x20,
+
+        /// <summary>Ness known (number of extension spatial streams)</summary>
+        NessKnown = 0x40,
+
+        /// <summary>Bandwidth</summary>
+        NessData = 0x80,
+    }

--- a/PacketDotNet/Ieee80211/RadioTapType.cs
+++ b/PacketDotNet/Ieee80211/RadioTapType.cs
@@ -133,6 +133,37 @@ namespace PacketDotNet.Ieee80211;
         RxFlags = 14,
 
         /// <summary>
+        /// IEEE80211_RADIOTAP_TX_FLAGS       u_int16_t         bitmap
+        /// Properties of transmitted frames.
+        /// </summary>
+        TxFlags = 15,
+
+        /// <summary>
+        ///  Indicates the MCS rate index as in IEEE_802.11n-2009
+        /// </summary>
+        Mcs = 19,
+
+        /// <summary>
+        /// The presence of this field indicates that the frame was received as part of an a-MPDU.
+        /// </summary>
+        AmpduStatus = 20,
+
+        /// <summary>
+        /// VHT (802.11ac PHY)
+        /// </summary>
+        VeryHighThroughput = 21,
+
+        /// <summary>
+        /// HE (802.11ax PHY)
+        /// </summary>
+        HighEfficiency = 23,
+
+        /// <summary>
+        /// HE MU. MIMO RU tone mapping
+        /// </summary>
+        HighEfficiencyMu = 24,
+
+        /// <summary>
         /// Indicates that the flags bitmaps have been extended
         /// </summary>
         Extended = 31

--- a/PacketDotNet/Ieee80211/RadioTapVhtBandwidth.cs
+++ b/PacketDotNet/Ieee80211/RadioTapVhtBandwidth.cs
@@ -1,5 +1,15 @@
-﻿namespace PacketDotNet.Ieee80211;
+﻿/*
+This file is part of PacketDotNet.
 
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+/*
+ * Copyright 2010 Chris Morgan <chmorgan@gmail.com>
+ */
+
+namespace PacketDotNet.Ieee80211;
 
 public enum RadioTapVhtBandwidth : byte
 {

--- a/PacketDotNet/Ieee80211/RadioTapVhtBandwidth.cs
+++ b/PacketDotNet/Ieee80211/RadioTapVhtBandwidth.cs
@@ -1,0 +1,55 @@
+﻿namespace PacketDotNet.Ieee80211;
+
+
+public enum RadioTapVhtBandwidth : byte
+{
+    /// <summary>
+    /// 20MHz bandwidth
+    /// </summary>
+    MHz20 = 0x00,
+
+    /// <summary>
+    /// 40MHz bandwidth
+    /// </summary>
+    MHz40 = 0x01,
+
+    /// <summary>
+    /// 40MHz bandwidth with 20L side band. Sideband index=0
+    /// </summary>
+    MHz40Side20L = 2,
+
+    /// <summary>
+    /// 40MHz bandwidth with 20U side band. Sideband index=1
+    /// </summary>
+    MHz40Side20U = 3,
+
+    /// <summary>
+    /// 80MHz bandwidth
+    /// </summary>
+    MHz80 = 4,
+    MHz80Side40L = 5,
+    MHz80Side40U = 6,
+    MHz80Side20LL = 7,
+    MHz80Side20LU = 8,
+    MHz80Side20UL = 9,
+    MHz80Side20UU = 10,
+
+    /// <summary>
+    /// 160MHz bandwidth
+    /// </summary>
+    MHz160 = 11,
+    MHz160Side80L = 12,
+    MHz160Side80U = 13,
+    MHz160Side40LL = 14,
+    MHz160Side40LU = 15,
+    MHz160Side40UL = 16,
+    MHz160Side40UU = 17,
+    MHz160Side20LLL = 18,
+    MHz160Side20LLU = 19,
+    MHz160Side20LUL = 20,
+    MHz160Side20LUU = 21,
+    MHz160Side20ULL = 22,
+    MHz160Side20ULU = 23,
+    MHz160Side20UUL = 24,
+    MHz160Side20UUU = 25,
+}

--- a/PacketDotNet/Ieee80211/RadioTapVhtCoding.cs
+++ b/PacketDotNet/Ieee80211/RadioTapVhtCoding.cs
@@ -1,4 +1,15 @@
-﻿using System;
+﻿/*
+This file is part of PacketDotNet.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+/*
+ * Copyright 2010 Chris Morgan <chmorgan@gmail.com>
+ */
+
+using System;
 
 namespace PacketDotNet.Ieee80211;
 

--- a/PacketDotNet/Ieee80211/RadioTapVhtCoding.cs
+++ b/PacketDotNet/Ieee80211/RadioTapVhtCoding.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace PacketDotNet.Ieee80211;
+
+[Flags]
+public  enum RadioTapVhtCoding : byte
+{
+    CodingForUser1 = 0x01,
+    CodingForUser2 = 0x02,
+    CodingForUser3 = 0x03,
+    CodingForUser4 = 0x04,
+
+    Unused = 0xf0
+}

--- a/PacketDotNet/Ieee80211/RadioTapVhtFlags.cs
+++ b/PacketDotNet/Ieee80211/RadioTapVhtFlags.cs
@@ -1,4 +1,15 @@
-﻿using System;
+﻿/*
+This file is part of PacketDotNet.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+/*
+ * Copyright 2010 Chris Morgan <chmorgan@gmail.com>
+ */
+
+using System;
 
 namespace PacketDotNet.Ieee80211;
 

--- a/PacketDotNet/Ieee80211/RadioTapVhtFlags.cs
+++ b/PacketDotNet/Ieee80211/RadioTapVhtFlags.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace PacketDotNet.Ieee80211;
+
+[Flags]
+public  enum RadioTapVhtFlags : byte
+{
+    /// <summary>
+    /// Space-time block coding. 
+    /// Set to 0 if no spatial streams of any user has STBC.
+    /// Set to 1 if all spatial streams of all users have STBC.
+    /// </summary>
+    Stbc = 0x01,
+
+    /// <summary>
+    /// Valid only for AP transmitters.
+    /// Set to 0 if STAs may doze during TXOP.
+    /// Set to 1 if STAs may not doze during TXOP or transmitter is non-AP.
+    /// </summary>
+    TxopPsNotAllowed = 0x02,
+
+    /// <summary>
+    /// Set to 0 for long GI.
+    /// Set to 1 for short GI.
+    /// </summary>
+    GuardInterval = 0x04,
+
+    /// <summary>
+    /// Valid only if short GI is used.
+    /// Set to 0 if NSYM mod 10 != 9 or short GI not used.
+    /// Set to 1 if NSYM mod 10 = 9.
+    /// </summary>
+    ShortGiNsymDisambiguation = 0x08,
+
+    /// <summary>
+    /// Set to 1 if one or more users are using LDPC and the encoding process resulted in extra OFDM symbol(s).
+    /// Set to 0 otherwise.
+    /// </summary>
+    LdpcExtraOfdmSymbol = 0x10,
+
+    /// <summary>
+    /// Valid only for SU PPDUs
+    /// </summary>
+    Beamformed = 0x20
+}

--- a/PacketDotNet/Ieee80211/RadioTapVhtKnown.cs
+++ b/PacketDotNet/Ieee80211/RadioTapVhtKnown.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace PacketDotNet.Ieee80211;
+
+[Flags]
+public enum RadioTapVhtKnown : ushort
+{
+    StbcKnown                       = 0x0001,
+    TxopPsNotAllowedKnown           = 0x0002,
+    GuardIntervalKnown              = 0x0004,
+    ShortGiNsymDisambiguationKnown  = 0x0008,
+    LdpcExtraOfdmSymbolKnown        = 0x0010,
+    BeamformedKnown                 = 0x0020,
+    BandwidthKnown                  = 0x0040,
+    GroupIdKnown                    = 0x0080,
+    PartialAidKnown                 = 0x0100
+}

--- a/PacketDotNet/Ieee80211/RadioTapVhtKnown.cs
+++ b/PacketDotNet/Ieee80211/RadioTapVhtKnown.cs
@@ -1,4 +1,15 @@
-﻿using System;
+﻿/*
+This file is part of PacketDotNet.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+/*
+ * Copyright 2010 Chris Morgan <chmorgan@gmail.com>
+ */
+
+using System;
 
 namespace PacketDotNet.Ieee80211;
 

--- a/PacketDotNet/Ieee80211/RadioTapVhtMcsNss.cs
+++ b/PacketDotNet/Ieee80211/RadioTapVhtMcsNss.cs
@@ -1,4 +1,15 @@
-﻿using System;
+﻿/*
+This file is part of PacketDotNet.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+/*
+ * Copyright 2010 Chris Morgan <chmorgan@gmail.com>
+ */
+
+using System;
 
 namespace PacketDotNet.Ieee80211;
 

--- a/PacketDotNet/Ieee80211/RadioTapVhtMcsNss.cs
+++ b/PacketDotNet/Ieee80211/RadioTapVhtMcsNss.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace PacketDotNet.Ieee80211;
+
+[Flags]
+public enum RadioTapVhtMcsNss : byte
+{
+    /// <summary>
+    /// Number of Spatial Streams
+    /// </summary>
+    Nss = 0x0f,
+
+    /// <summary>
+    /// MCS rate index
+    /// </summary>
+    Mcs = 0xf0
+}

--- a/Test/PacketType/Ieee80211/RadioTapFieldsTest.cs
+++ b/Test/PacketType/Ieee80211/RadioTapFieldsTest.cs
@@ -204,4 +204,70 @@ namespace Test.PacketType.Ieee80211;
 
             Assert.AreEqual(field.TxPower, recreatedField.TxPower);
         }
-    }
+
+        [Test]
+        public void Test_HighEfficiencyRadioTapField()
+        {
+            var field = new HighEfficiencyRadioTapField(RadioTapHighEfficiencyData1.StbcKnown, RadioTapHighEfficiencyData2.PeDisambiguityKnown, 3, 4, 5, 6);
+
+            var bytes = new byte[field.Length];
+            field.CopyTo(bytes, 0);
+
+            var recreatedField = new HighEfficiencyRadioTapField(new BinaryReader(new MemoryStream(bytes)));
+
+            Assert.AreEqual(field.Data1, recreatedField.Data1);
+            Assert.AreEqual(field.Data2, recreatedField.Data2);
+            Assert.AreEqual(field.Data3, recreatedField.Data3);
+            Assert.AreEqual(field.Data4, recreatedField.Data4);
+            Assert.AreEqual(field.Data5, recreatedField.Data5);
+            Assert.AreEqual(field.Data6, recreatedField.Data6);
+        }
+
+
+        [Test]
+        public void Test_VeryHighThroughputRadioTapField()
+        {
+            var field = new VeryHighThroughputRadioTapField(
+                RadioTapVhtKnown.BandwidthKnown | RadioTapVhtKnown.StbcKnown,
+                RadioTapVhtFlags.Stbc,
+                bandwidth: RadioTapVhtBandwidth.MHz160Side20LLU,
+                mcsNss1: (RadioTapVhtMcsNss)0xf1,
+                mcsNss2: (RadioTapVhtMcsNss)0xe2,
+                mcsNss3: (RadioTapVhtMcsNss)0xd3,
+                mcsNss4: (RadioTapVhtMcsNss)0xc4,
+                coding: RadioTapVhtCoding.CodingForUser1 | RadioTapVhtCoding.CodingForUser2 | RadioTapVhtCoding.CodingForUser3 | RadioTapVhtCoding.CodingForUser4,
+                groupId: 6,
+                partialAid: 7
+                );
+
+            var bytes = new byte[field.Length];
+            field.CopyTo(bytes, 0);
+
+            var recreatedField = new VeryHighThroughputRadioTapField(new BinaryReader(new MemoryStream(bytes)));
+
+            Assert.AreEqual(field.Known, recreatedField.Known);
+            Assert.AreEqual(field.Flags, recreatedField.Flags);
+            Assert.AreEqual(field.McsNss1, recreatedField.McsNss1);
+            Assert.AreEqual(field.McsNss2, recreatedField.McsNss2);
+            Assert.AreEqual(field.McsNss3, recreatedField.McsNss3);
+            Assert.AreEqual(field.McsNss4, recreatedField.McsNss4);
+            Assert.AreEqual(field.Coding, recreatedField.Coding);
+            Assert.AreEqual(field.GroupId, recreatedField.GroupId);
+            Assert.AreEqual(field.PartialAid, recreatedField.PartialAid);
+        }
+
+    [Test]
+        public void Test_McsRadioTapField()
+        {
+            var field = new McsRadioTapField(RadioTapMcsKnown.FecType|RadioTapMcsKnown.Bandwidth, RadioTapMcsFlags.Bandwidth, 12);
+
+            var bytes = new byte[field.Length];
+            field.CopyTo(bytes, 0);
+
+            var recreatedField = new McsRadioTapField(new BinaryReader(new MemoryStream(bytes)));
+
+            Assert.AreEqual(field.Known, recreatedField.Known);
+            Assert.AreEqual(field.Flags, recreatedField.Flags);
+            Assert.AreEqual(field.Mcs, recreatedField.Mcs);
+        }
+}


### PR DESCRIPTION
- Support for Wi-Fi/802.11 related radiotap fields: MCS, HE, VHT. Reference: https://www.radiotap.org/fields/defined
- Added file header
- Add parsing of VeryHighThroughput radio tap field
