### PR TITLE
fix RtpPacket and RtcpPacket bitmask setter logic

### DIFF
--- a/PacketDotNet/RtcpPacket.cs
+++ b/PacketDotNet/RtcpPacket.cs
@@ -117,7 +117,7 @@ namespace PacketDotNet;
         public int ReceptionReportCount
         {
             get => (Header.Bytes[Header.Offset] & RtcpFields.ReceptionReportCountMask);
-            set => Header.Bytes[Header.Offset] |= (byte) (value & RtcpFields.ReceptionReportCountMask);
+            set => Header.Bytes[Header.Offset] = (byte) ((Header.Bytes[Header.Offset] & ~RtcpFields.ReceptionReportCountMask) | (value & RtcpFields.ReceptionReportCountMask));
         }
 
         /// <summary>

--- a/PacketDotNet/RtpPacket.cs
+++ b/PacketDotNet/RtpPacket.cs
@@ -141,7 +141,7 @@ namespace PacketDotNet;
             get => Header.Bytes[Header.Offset] & RtpFields.CsrcCountMask;
             set
             {
-                Header.Bytes[Header.Offset] |= (byte) (value & RtpFields.CsrcCountMask);
+                Header.Bytes[Header.Offset] = (byte) ((Header.Bytes[Header.Offset] & ~RtpFields.CsrcCountMask) | (value & RtpFields.CsrcCountMask));
                 Header.Length = RtpFields.HeaderLength + CsrcCount * RtpFields.CsrcIdLength;
                 if (HasExtension)
                     Header.Length += RtpFields.ProfileSpecificExtensionHeaderLength + RtpFields.ExtensionLengthLength +
@@ -174,7 +174,7 @@ namespace PacketDotNet;
         public int PayloadType
         {
             get => Header.Bytes[Header.Offset + 1] & RtpFields.PayloadTypeMask;
-            set => Header.Bytes[Header.Offset + 1] |= (byte) (value & RtpFields.PayloadTypeMask);
+            set => Header.Bytes[Header.Offset + 1] = (byte) ((Header.Bytes[Header.Offset + 1] & ~RtpFields.PayloadTypeMask) | (value & RtpFields.PayloadTypeMask));
         }
 
         /// <summary>


### PR DESCRIPTION
The PayloadType setter uses `header[offset] |= value & bitmask` to set the value.

However this only sets the bits in the new value, it does not unset existing bits not in the value. While the setter works when the current header byte is zero, it fails if the RTP header already has a payload type value to be changed.

The same bug also appears to affect ReceptionReportCount and CsrcCount.