### PR TITLE
Fix CRC32 hash for non-zero buffer offsets

### DIFF
--- a/PacketDotNet/Utils/Crc32.cs
+++ b/PacketDotNet/Utils/Crc32.cs
@@ -112,7 +112,7 @@ namespace PacketDotNet.Utils;
         /// <summary>Routes data written to the object into the hash algorithm for computing the hash.</summary>
         protected override void HashCore(byte[] buffer, int offset, int count)
         {
-            for (var i = offset; i < count; i++)
+            for (var i = offset; i < offset + count; i++)
             {
                 ulong ptr = (_crc & 0xFF) ^ buffer[i];
                 _crc >>= 8;


### PR DESCRIPTION
The CRC32 hashing utility function currently doesn't account for the buffer offset when calculating the hash, resulting in incorrect hash values when the offset is non-zero.

All references to this hashing function elsewhere in the solution have an offset of zero, which is why this issue has gone undetected.