### PR TITLE
Fix duplicated header in IcmpV6Packet with Ndp

### DIFF
--- a/PacketDotNet/IcmpV6Packet.cs
+++ b/PacketDotNet/IcmpV6Packet.cs
@@ -47,7 +47,8 @@ namespace PacketDotNet;
             Header = new ByteArraySegment(byteArraySegment.Bytes, byteArraySegment.Offset, 4);
 
             // parse the payload
-            PayloadPacketOrData = new LazySlim<PacketOrByteArraySegment>(() => ParseNextSegment(byteArraySegment,
+            var payload = new ByteArraySegment(byteArraySegment.Bytes, byteArraySegment.Offset + Header.Length, byteArraySegment.Length - Header.Length);
+            PayloadPacketOrData = new LazySlim<PacketOrByteArraySegment>(() => ParseNextSegment(payload,
                                                                                                 Type));
         }
 
@@ -146,7 +147,7 @@ namespace PacketDotNet;
                     payloadPacketOrData.Packet = new NdpRedirectMessagePacket(header);
                     break;
                 default:
-                    payloadPacketOrData.ByteArraySegment = new ByteArraySegment(header.Bytes, header.Offset + 4, header.Length - 4);
+                    payloadPacketOrData.ByteArraySegment = new ByteArraySegment(header.Bytes, header.Offset, header.Length);
                     break;
             }
 

--- a/PacketDotNet/NdpFields.cs
+++ b/PacketDotNet/NdpFields.cs
@@ -10,23 +10,23 @@ namespace PacketDotNet;
 
     public struct NdpFields
     {
-        public static int NeighborAdvertisementFlagsOffset = 4;
-        public static int NeighborAdvertisementOptionsOffset = 24;
-        public static int NeighborAdvertisementTargetAddressOffset = 8;
+        public static int NeighborAdvertisementFlagsOffset = 0;
+        public static int NeighborAdvertisementOptionsOffset = 20;
+        public static int NeighborAdvertisementTargetAddressOffset = 4;
 
-        public static int NeighborSolicitationOptionsAddressOffset = 24;
-        public static int NeighborSolicitationTargetAddressOffset = 8;
+        public static int NeighborSolicitationOptionsAddressOffset = 20;
+        public static int NeighborSolicitationTargetAddressOffset = 4;
 
-        public static int RouterAdvertisementCurrentHopLimitOffset = 4;
-        public static int RouterAdvertisementExtOffset = 5;
-        public static int RouterAdvertisementOptionsOffset = 16;
-        public static int RouterAdvertisementReachableTimeOffset = 8;
-        public static int RouterAdvertisementRetransmitTimerOffset = 12;
-        public static int RouterAdvertisementRouterLifetimeOffset = 6;
+        public static int RouterAdvertisementCurrentHopLimitOffset = 0;
+        public static int RouterAdvertisementExtOffset = 1;
+        public static int RouterAdvertisementOptionsOffset = 12;
+        public static int RouterAdvertisementReachableTimeOffset = 4;
+        public static int RouterAdvertisementRetransmitTimerOffset = 8;
+        public static int RouterAdvertisementRouterLifetimeOffset = 2;
 
-        public static int RouterSolicitationOptionsOffset = 8;
+        public static int RouterSolicitationOptionsOffset = 4;
 
-        public static int RedirectMessageTargetAddressOffset = 8;
-        public static int RedirectMessageDestinationAddressOffset = 24;
-        public static int RedirectMessageOptionsOffset = 40;
+        public static int RedirectMessageTargetAddressOffset = 4;
+        public static int RedirectMessageDestinationAddressOffset = 20;
+        public static int RedirectMessageOptionsOffset = 36;
     }

--- a/Test/PacketType/IPv6PacketTest.cs
+++ b/Test/PacketType/IPv6PacketTest.cs
@@ -44,7 +44,7 @@ namespace Test.PacketType;
             ClassicAssert.AreEqual(IPAddress.Parse("ff02::2"), ip.DestinationAddress);
             ClassicAssert.AreEqual(IPVersion.IPv6, ip.Version);
             ClassicAssert.AreEqual(ProtocolType.IcmpV6, ip.Protocol);
-            ClassicAssert.AreEqual(20, ip.PayloadPacket.Bytes.Length, "ip.PayloadPacket.Bytes.Length mismatch");
+            ClassicAssert.AreEqual(16, ip.PayloadPacket.Bytes.Length, "ip.PayloadPacket.Bytes.Length mismatch");
             ClassicAssert.AreEqual(255, ip.HopLimit);
             ClassicAssert.AreEqual(255, ip.TimeToLive);
             Console.WriteLine("Failed: ip.ComputeIPChecksum() not implemented.");

--- a/Test/PacketType/IcmpV6PacketTest.cs
+++ b/Test/PacketType/IcmpV6PacketTest.cs
@@ -7,6 +7,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using NUnit.Framework;
@@ -91,6 +92,9 @@ namespace Test.PacketType;
 
             var pNs = Packet.ParsePacket(nsRawCapture.GetLinkLayers(), nsRawCapture.Data);
             ClassicAssert.IsNotNull(pNs);
+
+            // Verify the packet is serailized correctly.
+            ClassicAssert.IsTrue(pNs.Bytes.SequenceEqual(nsRawCapture.Data));
 
             var neighborSolicitationPacket = pNs.Extract<NdpNeighborSolicitationPacket>();
             ClassicAssert.IsNotNull(neighborSolicitationPacket);


### PR DESCRIPTION
# The Bug
When an IcmpV6 packet with Ndp is parsed, the IcmpV6 header (Type, Code, Checksum) is saved both in the `IcmpV6Packet` object and in the relevant Ndp packet object (e.g. `NdpNeighborSolicitationPacket`).
**Therefore, when serializing a parsed Ndp packet, we get a different byte array than the original packet data.**
See the verification I added to [Test/PacketType/IcmpV6PacketTest.cs](https://github.com/dotpcap/packetnet/compare/master...HadarShahar:fix_icmpv6_duplicated_header?expand=1#diff-37f7afcc9882f79551b25801c2472149145d470dc3575c83e7efdbca42d8d692), that failed before the fix and passes now.
BTW, [this issue](https://github.com/dotpcap/packetnet/issues/204) seems to a be a result of this bug. 

# The Fix
- When parsing the payload of an IcmpV6Packet, skip the header - we already parsed it.
- Decrease all the offsets in `NdpFields` by the size of IcmpV6 packet header (4 bytes).
- Fix a wrong assertion in [Test/PacketType/IPv6PacketTest.cs](https://github.com/dotpcap/packetnet/compare/master...HadarShahar:fix_icmpv6_duplicated_header?expand=1#diff-9dde8b130dbf69d1e723c87abf6df86a1922fe1f4d1943a0b9c90eb6e7855589) due to this bug.