### PR TITLE
Add net6.0 to TargetFrameworks in project file

### DIFF
--- a/PacketDotNet/PacketDotNet.csproj
+++ b/PacketDotNet/PacketDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net9.0;net472</TargetFrameworks>
     <Authors>Chris Morgan (chmorgan@gmail.com)</Authors>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Motivation:
Some people are still using net6.0, at least we are.